### PR TITLE
Add logging and manual trigger for VOC discovery workflow

### DIFF
--- a/backend/api/intelligence.py
+++ b/backend/api/intelligence.py
@@ -77,8 +77,23 @@ def voc_discovery():
         return jsonify({'error': 'segment_name is required'}), 400
 
     try:
-        reddit_api_key = os.getenv('SCRAPECREATORS_API_KEY')
-        discovery_payload = run_voc_discovery(segment_name=segment_name, reddit_api_key=reddit_api_key)
+        config_overrides = {
+            key: value
+            for key, value in payload.items()
+            if key
+            in {
+                "enable_reddit",
+                "enable_trends",
+                "enable_curated_queries",
+                "google_trends",
+                "trends_keywords",
+                "subreddits",
+            }
+        }
+        discovery_payload = run_voc_discovery(
+            segment_name=segment_name,
+            segment_config=config_overrides or None,
+        )
         return jsonify(discovery_payload)
     except VOCDiscoveryError as exc:
         return jsonify({'error': str(exc)}), 400


### PR DESCRIPTION
## Summary
- enhance the VOC discovery backend with detailed progress logs, resilient Gemini JSON parsing, and rate-limited Google Trends lookups
- expose configuration overrides through the API so the frontend can toggle discovery options
- add a Start Discovery control, live log viewer, and manual run flow to the Trend Discovery UI

## Testing
- npm run lint *(fails: pre-existing lint errors in unrelated components)*

------
https://chatgpt.com/codex/tasks/task_b_68da64d6ac908327bd539090ffeac15b