### PR TITLE
Migrate Gemini client to google-genai SDK

### DIFF
--- a/backend/core/gemini_client.py
+++ b/backend/core/gemini_client.py
@@ -9,8 +9,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, Optional
 
-import google.generativeai as genai
-from google.generativeai import types
+from google import genai
+from google.genai import types
 
 
 class GeminiClientError(RuntimeError):

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -21,7 +21,7 @@ google-api-core==2.25.2
 google-api-python-client==2.184.0
 google-auth==2.41.1
 google-auth-httplib2==0.2.0
-google-generativeai==0.5.0
+google-genai==1.41.0
 googleapis-common-protos==1.70.0
 greenlet==3.2.3
 grpcio==1.75.1


### PR DESCRIPTION
## Summary
- switch the Gemini client wrapper to import the new google-genai SDK
- update backend Python dependencies to require google-genai 1.41.0 instead of google-generativeai

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'intelligence')*


------
https://chatgpt.com/codex/tasks/task_b_68e2fab3ed788327b2921467c0bbc833