### PR TITLE
Refactor VOC pre-scoring to structured per-post workflow

### DIFF
--- a/backend/api/intelligence_stages.py
+++ b/backend/api/intelligence_stages.py
@@ -124,13 +124,14 @@ def pre_score_posts():
         config = load_segment_config(segment_name)
         gemini_client = GeminiClient()
         
-        # Batch pre-score using title + snippet only (fast)
-        from intelligence.voc_synthesis import batch_prescore_posts
-        prescored_posts, warnings = batch_prescore_posts(
+        # Pre-score using title + snippet only (fast)
+        from intelligence.voc_synthesis import pre_score_posts
+
+        prescored_posts, warnings = pre_score_posts(
             raw_posts,
-            config,
             segment_name,
-            gemini_client,
+            gemini_client=gemini_client,
+            segment_config=config,
         )
         
         # Filter by prescore threshold

--- a/backend/intelligence/config/prompts/voc_reddit_analysis_prompt.txt
+++ b/backend/intelligence/config/prompts/voc_reddit_analysis_prompt.txt
@@ -15,21 +15,15 @@ SCORING CRITERIA (0-10):
 - Segment Fit (0-3 points): Is this problem specifically relevant to {segment_name}?
 - Outstaffer Solution Match (0-3 points): Can our recruitment, EOR, AI screening, or HRIS platform directly solve this problem?
 
-Return a compact JSON object with the following keys only:
+Return ONLY a JSON object with exactly these keys:
 {{
-  "relevance_score": 6.5,
+  "relevance_score": number between 0 and 10,
   "reasoning": "Short explanation (2-3 sentences max) referencing evidence from the discussion and explaining which Outstaffer service could help",
   "identified_pain_point": "Concise description (one sentence) of the core problem described by the community",
   "outstaffer_solution_angle": "Recruitment" OR "EOR" OR "AI Screening" OR "HRIS" OR "None"
 }}
 
 STRICT REQUIREMENTS:
-- Return ONLY valid JSON object, no text before or after
-- Do NOT wrap in markdown code fences or backticks
-- All four keys MUST be present: relevance_score, reasoning, identified_pain_point, outstaffer_solution_angle
-- relevance_score must be a number between 0 and 10 (can be float like 6.5)
-- reasoning must be a non-empty string (2-3 sentences max)
-- identified_pain_point must be a non-empty string (one sentence)
-- outstaffer_solution_angle must be one of: "Recruitment", "EOR", "AI Screening", "HRIS", or "None"
+- Return only valid JSON with those keys, no extra fields or text.
+- Do NOT wrap in markdown code fences or backticks.
 - If you cannot analyze the discussion, return: {{"relevance_score": 5.0, "reasoning": "Insufficient context to determine relevance to Outstaffer's services", "identified_pain_point": "Unable to determine specific pain point from discussion", "outstaffer_solution_angle": "None"}}
-- Ensure the JSON is properly formatted and parseable

--- a/backend/intelligence/config/prompts/voc_reddit_prescore_prompt.txt
+++ b/backend/intelligence/config/prompts/voc_reddit_prescore_prompt.txt
@@ -1,0 +1,24 @@
+You are assisting with Voice of Customer discovery for the segment "{segment_name}".
+
+AUDIENCE CONTEXT: {audience}
+PRIORITY SIGNALS:
+{priorities}
+
+Evaluate the following Reddit post from r/{subreddit} and determine whether it deserves deeper analysis.
+
+POST ID: {post_id}
+TITLE: {post_title}
+SNIPPET:
+{post_snippet}
+
+Return ONLY a JSON object with these keys:
+{{
+  "post_id": "{post_id}",
+  "score": number between 0 and 1 reflecting how relevant the post is for {segment_name},
+  "priority": boolean indicating if this post should be fast-tracked for enrichment,
+  "reason": "One short sentence describing why the post is or is not valuable"
+}}
+
+STRICT REQUIREMENTS:
+- Do not include any additional fields or text.
+- If information is insufficient, still return a valid object with score 0.0 and priority false.

--- a/backend/intelligence/models.py
+++ b/backend/intelligence/models.py
@@ -1,0 +1,61 @@
+"""Shared data models for intelligence workflows."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from pydantic import BaseModel, ConfigDict
+
+
+class PreScoreResult(BaseModel):
+    """Validated Gemini response for Reddit pre-scoring."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    post_id: str
+    score: float
+    priority: bool
+    reason: Optional[str] = None
+
+
+class RedditAnalysis(BaseModel):
+    """Structured Reddit enrichment payload."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    relevance_score: float
+    reasoning: str
+    identified_pain_point: str
+    outstaffer_solution_angle: str
+
+
+PRESCORE_RESPONSE_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "post_id": {"type": "string"},
+        "score": {"type": "number"},
+        "priority": {"type": "boolean"},
+        "reason": {"type": "string"},
+    },
+    "required": ["post_id", "score", "priority"],
+}
+
+
+REDDIT_ANALYSIS_RESPONSE_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "relevance_score": {"type": "number"},
+        "reasoning": {"type": "string"},
+        "identified_pain_point": {"type": "string"},
+        "outstaffer_solution_angle": {
+            "type": "string",
+            "enum": ["Recruitment", "EOR", "AI Screening", "HRIS", "None"],
+        },
+    },
+    "required": [
+        "relevance_score",
+        "reasoning",
+        "identified_pain_point",
+        "outstaffer_solution_angle",
+    ],
+}

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -10,3 +10,4 @@ httpx==0.28.1
 tavily-python==0.3.0
 gunicorn==22.0.0
 google-cloud-firestore==2.17.1
+pydantic==2.9.2

--- a/backend/tests/test_voc_synthesis.py
+++ b/backend/tests/test_voc_synthesis.py
@@ -1,0 +1,109 @@
+import pathlib
+import sys
+import time
+from typing import Any, Dict
+
+import pytest
+
+PROJECT_ROOT = pathlib.Path(__file__).resolve().parents[2]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+BACKEND_ROOT = PROJECT_ROOT / "backend"
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from core.gemini_client import GeminiClientError
+from intelligence import voc_synthesis
+from intelligence.models import PreScoreResult
+
+
+class DummyResponse:
+    def __init__(self, data: Dict[str, Any]):
+        self.data = data
+        self.raw_text = "{}"
+
+
+class DummyGemini:
+    def __init__(self, payload: Dict[str, Any]):
+        self._payload = payload
+        self.default_model = "test-model"
+
+    def generate_json_response(self, *args: Any, **kwargs: Any) -> DummyResponse:
+        return DummyResponse(self._payload)
+
+
+def test_pre_score_post_success() -> None:
+    post = {"id": "abc123", "title": "Hiring help", "content_snippet": "We need EOR"}
+    gemini = DummyGemini({
+        "post_id": "abc123",
+        "score": 0.85,
+        "priority": True,
+        "reason": "Direct hiring challenge",
+    })
+
+    result = voc_synthesis.pre_score_post(
+        post,
+        "Segment",
+        gemini_client=gemini,
+        segment_config={"audience": "HR", "priorities": ["Global hiring"]},
+    )
+
+    assert isinstance(result, PreScoreResult)
+    assert result.post_id == "abc123"
+    assert result.score == pytest.approx(0.85)
+    assert result.priority is True
+    assert result.reason == "Direct hiring challenge"
+
+
+def test_pre_score_post_invalid_payload_raises() -> None:
+    post = {"id": "abc123", "title": "Hiring help", "content_snippet": "We need EOR"}
+    gemini = DummyGemini({"post_id": "abc123", "priority": True})
+
+    with pytest.raises(GeminiClientError):
+        voc_synthesis.pre_score_post(
+            post,
+            "Segment",
+            gemini_client=gemini,
+        )
+
+
+def test_pre_score_posts_collects_warnings(monkeypatch: pytest.MonkeyPatch) -> None:
+    posts = [{"id": "1"}, {"id": "2"}]
+
+    def fake_pre_score_post(post: Dict[str, Any], *_args: Any, **_kwargs: Any) -> PreScoreResult:
+        if post["id"] == "1":
+            return PreScoreResult(post_id="1", score=0.6, priority=True, reason="Good fit")
+        raise GeminiClientError("boom")
+
+    monkeypatch.setattr(voc_synthesis, "pre_score_post", fake_pre_score_post)
+
+    scored, warnings = voc_synthesis.pre_score_posts(
+        posts,
+        "Segment",
+        gemini_client=DummyGemini({}),
+    )
+
+    assert len(scored) == 1
+    assert scored[0]["prescore"]["relevance_score"] == pytest.approx(0.6)
+    assert warnings and "boom" in warnings[0]
+
+
+def test_pre_score_posts_preserves_input_order(monkeypatch: pytest.MonkeyPatch) -> None:
+    posts = [{"id": "1"}, {"id": "2"}]
+
+    def fake_pre_score_post(post: Dict[str, Any], *_args: Any, **_kwargs: Any) -> PreScoreResult:
+        if post["id"] == "1":
+            time.sleep(0.05)
+        return PreScoreResult(post_id=post["id"], score=float(post["id"]), priority=False, reason="")
+
+    monkeypatch.setattr(voc_synthesis, "pre_score_post", fake_pre_score_post)
+
+    scored, warnings = voc_synthesis.pre_score_posts(
+        posts,
+        "Segment",
+        gemini_client=DummyGemini({}),
+    )
+
+    assert not warnings
+    assert [post["id"] for post in scored] == ["1", "2"]


### PR DESCRIPTION
## Summary
- add pydantic models and JSON schemas to validate VOC Gemini responses
- refactor the VOC pre-score stage to call Gemini per post with concurrency and a new prompt
- enforce schema-driven enrichment responses, extend the Gemini client, and cover the workflow with unit tests

## Testing
- pytest backend/tests/test_voc_synthesis.py

------
https://chatgpt.com/codex/tasks/task_b_68e30afa79c48327b357869781df42d8