### PR TITLE
feat: add structured logging and responses to agent researcher

### DIFF
--- a/backend/intelligence/models.py
+++ b/backend/intelligence/models.py
@@ -1,10 +1,10 @@
-"""Shared data models for intelligence workflows."""
+"""Pydantic models shared across intelligence modules."""
 
 from __future__ import annotations
 
-from typing import Optional
+from typing import List, Optional
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class PreScoreResult(BaseModel):
@@ -59,3 +59,68 @@ REDDIT_ANALYSIS_RESPONSE_SCHEMA = {
         "outstaffer_solution_angle",
     ],
 }
+
+
+class SearchQuery(BaseModel):
+    """A precise, actionable web search query tailored to the research mission."""
+
+    query: str = Field(
+        ...,
+        description="A precise, actionable web search query tailored to the research mission.",
+    )
+
+
+class QueryPlan(BaseModel):
+    """Structured set of search queries returned by the planner."""
+
+    queries: List[SearchQuery] = Field(
+        ...,
+        description="A list of 3-5 high-quality, targeted search queries.",
+    )
+
+
+class TalkingPoint(BaseModel):
+    """Insight derived from the research corpus."""
+
+    point: str = Field(
+        ...,
+        description="A key insight or talking point derived from the content.",
+    )
+    supporting_urls: List[str] = Field(
+        default_factory=list,
+        description="URLs of sources that support this point.",
+    )
+
+
+class CampaignIdea(BaseModel):
+    """Creative activation derived from the research."""
+
+    idea: str = Field(
+        ...,
+        description="A creative campaign idea or content angle.",
+    )
+    target_channels: List[str] = Field(
+        default_factory=list,
+        description="Recommended channels for this campaign (e.g., Blog, LinkedIn).",
+    )
+
+
+class ContentTheme(BaseModel):
+    """High-level theme synthesized from the research corpus."""
+
+    theme_title: str = Field(
+        ...,
+        description="A high-level theme or topic discovered in the research.",
+    )
+    summary: str = Field(
+        ...,
+        description="A brief summary of the theme, explaining its relevance to the target audience.",
+    )
+    talking_points: List[TalkingPoint]
+    campaign_ideas: List[CampaignIdea]
+
+
+class SynthesisResult(BaseModel):
+    """Structured synthesis output returned by Gemini."""
+
+    content_themes: List[ContentTheme]

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -10,4 +10,5 @@ httpx==0.28.1
 tavily-python==0.3.0
 gunicorn==22.0.0
 google-cloud-firestore==2.17.1
-pydantic==2.9.2
+pydantic>=2.0
+instructor>=1.0


### PR DESCRIPTION
## Summary
- add pydantic models for query planning and synthesis outputs and expand shared intelligence models module
- integrate instructor with the Gemini client to request structured responses and emit additional agent logs
- enhance agent researcher logging around Gemini calls while parsing structured responses and persisting synthesis data

## Testing
- python -m compileall backend/intelligence backend/core

------
https://chatgpt.com/codex/tasks/task_b_68e381abfe008327879071a51640f1be