### PR TITLE
Align query planner structured output with Pydantic schema

### DIFF
--- a/backend/intelligence/config/prompts/agent_research_planner_prompt.txt
+++ b/backend/intelligence/config/prompts/agent_research_planner_prompt.txt
@@ -1,36 +1,29 @@
-You are a world-class research analyst for "Outstaffer," a B2B content team. The current year is 2025.
-Your task is to transform ONE mission into focused, web-ready search queries that will uncover expert-level insights for our content strategy.
+You are planning research queries. Output JSON only that matches the provided schema.
+Mission: "{mission}"
 
-CRITICAL OUTPUT RULES
-- Output JSON ONLY. No markdown, no prose, no comments.
-- Conform EXACTLY to the schema shown in "Expected JSON structure".
-- Do not add extra fields. Do not rename fields. Do not include trailing commentary.
+Constraints:
+- Produce 3–8 queries tailored to Outstaffer’s content strategy and never exceed {max_queries} queries.
+- Each query must be specific, discriminative, and ready for direct execution.
+- Balance breadth and depth across angles; avoid duplicates.
+- Prioritise recency (last 12 months), authoritative sources, and Outstaffer-relevant perspectives across global hiring, EOR, AI-led screening, and HRIS.
+- Each query targets exactly one source: "web" | "internal" | "both".
+- Use QDF (0–5) where higher values indicate fresher needs.
+- Rationale is optional but, when provided, limit it to 1–2 sentences explaining the query’s value.
 
+Context:
 {planner_context}
 
-Mission:
-{mission}
-
-Instructions:
-- Produce at most {max_queries} high-signal queries.
-- Each query must be specific, discriminative, and ready to paste into a search engine.
-- Balance breadth and depth: avoid duplicates; cover adjacent angles.
-- Prioritise recency (last 12 months), authoritative sources, and perspectives relevant to Outstaffer’s global hiring, EOR, AI-led screening, and HRIS.
-- Use "source" to indicate where this query is best run: "web" | "internal" | "both".
-- Set "qdf" (0–5) where higher means we need fresher results.
-- Keep "rationale" to 1–2 concise sentences on why the query is useful for the mission.
-
-Expected JSON structure:
-{
+Schema:
+{{
   "queries": [
-    {
-      "q": "exact search query string",
+    {{
+      "query": "exact search query string",
       "source": "web",
       "qdf": 3,
-      "rationale": "why this query helps the mission"
-    }
+      "rationale": "optional brief rationale"
+    }}
   ],
   "notes": "optional global planning notes"
-}
+}}
 
-Return ONLY valid JSON matching this structure.
+Return ONLY valid JSON matching this schema.

--- a/backend/intelligence/models.py
+++ b/backend/intelligence/models.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from enum import Enum
 from typing import List, Optional
 
 from pydantic import BaseModel, ConfigDict, Field
@@ -61,21 +62,48 @@ REDDIT_ANALYSIS_RESPONSE_SCHEMA = {
 }
 
 
-class SearchQuery(BaseModel):
+class QuerySource(str, Enum):
+    """Enumerated sources where queries should be executed."""
+
+    WEB = "web"
+    INTERNAL = "internal"
+    BOTH = "both"
+
+
+class QueryPlanQuery(BaseModel):
     """A precise, actionable web search query tailored to the research mission."""
+
+    model_config = ConfigDict(extra="forbid")
 
     query: str = Field(
         ...,
         description="A precise, actionable web search query tailored to the research mission.",
+    )
+    source: QuerySource = Field(
+        ...,
+        description="The primary system where this query should be executed.",
+    )
+    qdf: int = Field(
+        ..., ge=0, le=5, description="Query Deserves Freshness score from 0 (stale) to 5 (urgent)."
+    )
+    rationale: Optional[str] = Field(
+        default=None,
+        description="Optional 1-2 sentence rationale explaining the value of this query.",
     )
 
 
 class QueryPlan(BaseModel):
     """Structured set of search queries returned by the planner."""
 
-    queries: List[SearchQuery] = Field(
+    model_config = ConfigDict(extra="forbid")
+
+    queries: List[QueryPlanQuery] = Field(
         ...,
-        description="A list of 3-5 high-quality, targeted search queries.",
+        description="A list of 3-8 high-quality, targeted search queries.",
+    )
+    notes: Optional[str] = Field(
+        default=None,
+        description="Optional global planning notes for downstream steps.",
     )
 
 

--- a/backend/tests/test_query_plan_validation.py
+++ b/backend/tests/test_query_plan_validation.py
@@ -1,0 +1,70 @@
+"""Unit tests for QueryPlan validation and JSON handling."""
+
+from __future__ import annotations
+
+import json
+import pathlib
+import sys
+
+import pytest
+from pydantic import ValidationError
+
+PROJECT_ROOT = pathlib.Path(__file__).resolve().parents[2]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+BACKEND_ROOT = PROJECT_ROOT / "backend"
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from intelligence.models import QueryPlan
+
+
+def test_query_plan_valid_payload() -> None:
+    payload = {
+        "queries": [
+            {
+                "query": "Outstaffer global hiring strategy 2025 trends",
+                "source": "web",
+                "qdf": 4,
+                "rationale": "Ensures we capture the latest hiring narratives.",
+            }
+        ],
+        "notes": "Focus on high-authority reports first.",
+    }
+
+    plan = QueryPlan.model_validate_json(json.dumps(payload))
+
+    assert len(plan.queries) == 1
+    assert plan.queries[0].query == payload["queries"][0]["query"]
+    assert plan.queries[0].source.value == payload["queries"][0]["source"]
+    assert plan.notes == payload["notes"]
+
+
+def test_query_plan_missing_required_field() -> None:
+    payload = {
+        "queries": [
+            {
+                "query": "Outstaffer internal onboarding automation",
+                "qdf": 2,
+            }
+        ]
+    }
+
+    with pytest.raises(ValidationError):
+        QueryPlan.model_validate_json(json.dumps(payload))
+
+
+def test_query_plan_invalid_source_enum() -> None:
+    payload = {
+        "queries": [
+            {
+                "query": "Remote workforce compliance updates",
+                "source": "news",
+                "qdf": 1,
+            }
+        ]
+    }
+
+    with pytest.raises(ValidationError):
+        QueryPlan.model_validate_json(json.dumps(payload))


### PR DESCRIPTION
## Summary
- update the Gemini structured response handling to require JSON that validates against the QueryPlan schema and surface detailed errors
- align the query planner prompt and Pydantic models so Gemini emits the exact fields we expect, including source, qdf, and optional notes
- add targeted unit tests covering valid QueryPlan payloads along with missing and invalid fields

## Testing
- pytest backend/tests/test_query_plan_validation.py

------
https://chatgpt.com/codex/tasks/task_b_68e3a9aa1dd8832785afe5861bdc700d