### PR TITLE
Enforce structured JSON for quick research flows

### DIFF
--- a/backend/api/analyze.py
+++ b/backend/api/analyze.py
@@ -9,10 +9,10 @@ analyze_bp = Blueprint('analyze', __name__)
 @analyze_bp.route('/analyze', methods=['POST'])
 def analyze_content():
     """Analyze content with Gemini AI"""
-    data = request.get_json()
+    data = request.get_json() or {}
     content = data.get('content')
     custom_prompt = data.get('prompt')
-    
+
     if not content:
         return jsonify({'error': 'Content is required'}), 400
     

--- a/backend/api/synthesize.py
+++ b/backend/api/synthesize.py
@@ -1,25 +1,29 @@
-# backend/api/synthesize.py
-from flask import Blueprint, request, jsonify
+"""Content synthesis API endpoint."""
+from flask import Blueprint, jsonify, request
+
 from core.pipeline import ContentPipeline
 
-synthesize_bp = Blueprint('synthesize', __name__)
 
-@synthesize_bp.route('/synthesize', methods=['POST'])
+synthesize_bp = Blueprint("synthesize", __name__)
+
+
+@synthesize_bp.route("/synthesize", methods=["POST"])
 def synthesize_content():
-    """Synthesizes an article from multiple content sources"""
-    data = request.get_json()
-    query = data.get('query')
-    contents = data.get('contents') # Expect a list of {url, title, markdown}
+    """Synthesize insights from multiple content sources."""
+
+    data = request.get_json() or {}
+    query = data.get("query")
+    contents = data.get("contents")  # Expect a list of {url, title, markdown}
 
     if not contents or not isinstance(contents, list):
-        return jsonify({'error': 'A list of content is required'}), 400
+        return jsonify({"error": "A list of content is required"}), 400
+
     if not query:
-        return jsonify({'error': 'A query or topic is required'}), 400
+        return jsonify({"error": "A query or topic is required"}), 400
 
     try:
         pipeline = ContentPipeline()
-        # We'll create a new method in the pipeline for this
         result = pipeline.synthesize_article(query, contents)
         return jsonify(result)
-    except Exception as e:
-        return jsonify({'error': str(e)}), 500
+    except Exception as exc:  # noqa: BLE001
+        return jsonify({"error": str(exc)}), 500

--- a/backend/intelligence/config/prompts/article_analysis_prompt.txt
+++ b/backend/intelligence/config/prompts/article_analysis_prompt.txt
@@ -1,0 +1,14 @@
+You are a professional research analyst and content strategist for Outstaffer, a company that provides AI-powered global hiring and Employer of Record (EOR) services.
+You must respond with JSON only that conforms to the ArticleAnalysis schema.
+No markdown, no code fences, no additional fields.
+
+Your task is to review a single scraped article and distill the most actionable takeaways for Outstaffer's marketing and sales teams. Prioritize insights that help U.S. staffing firms and Australian B2B companies understand global hiring, remote team enablement, compliance, and workforce productivity trends.
+
+When crafting the overview, capture the central narrative in 2–3 sentences that explain why the article matters. For the key_insights array, provide 3–6 concise bullet strings that highlight concrete facts, statistics, or recommendations. In outstaffer_opportunity, write 1–2 short paragraphs that translate the article into a clear commercial or positioning opportunity for Outstaffer.
+
+Additional analyst direction (optional): {additional_instructions}
+
+Article content to analyze:
+{content}
+
+If you lack information for a field, return "" or [] for that field.

--- a/backend/intelligence/config/prompts/synthesize_article_prompt.txt
+++ b/backend/intelligence/config/prompts/synthesize_article_prompt.txt
@@ -1,36 +1,17 @@
 You are a professional research analyst and content strategist for Outstaffer, a company that provides AI-powered global hiring and Employer of Record (EOR) services.
+You must respond with JSON only that conforms to the MultiArticleAnalysis schema.
+No markdown, no code fences, no additional fields.
 
-**Part 1: Research Article**
-Your first task is to write a comprehensive, well-structured mini-research article on the topic: "{query}".
-Use the provided source materials to synthesize a new, original piece of writing.
+Your task is to synthesize intelligence from multiple scraped sources related to the topic "{query}". Evaluate authority, recency, and relevance for U.S. staffing firms and Australian B2B leaders exploring global hiring, distributed teams, and compliance enablement.
 
-Your article should have:
-1.  An engaging title.
-2.  A brief introduction summarizing the topic.
-3.  Several paragraphs that explore the key themes, trends, and data from the sources.
-4.  A concluding paragraph that summarizes the main takeaways.
+Use the source material to craft:
+- overview: 3–5 sentences weaving a narrative across the sources that explains why the topic matters now.
+- key_insights: 5–10 concise bullet strings highlighting distinct data points, expert quotes, or actionable recommendations. Attribute insights to their sources when possible.
+- outstaffer_opportunity: A crisp strategy paragraph that positions how Outstaffer can support prospects based on the combined findings.
+- cross_article_themes: 3–6 short themes that surface repeating ideas, tensions, or opportunities seen across the sources.
 
-Source Material:
+Source material to analyze:
 {source_material}
 
----
-**Part 2: Strategic Analysis & Content Generation**
-After writing the article, provide a strategic analysis and a ready-to-use LinkedIn post.
----
-
-**Instructions:**
-Structure your entire response as a single, clean JSON object. Do not include any text or markdown formatting outside of the JSON structure.
-
-**Example JSON output format:**
-{{
-  "article": "Your full research article text here...",
-  "outstaffer_analysis": {{
-    "relevance_opportunity": "How this topic relates to Outstaffer's business and client opportunities.",
-    "key_talking_point": "The single most important message for the sales/marketing team."
-  }},
-  "linkedin_post": {{
-    "angle": "A compelling angle for the LinkedIn post.",
-    "text": "The full, ready-to-post text for LinkedIn, written professionally.",
-    "hashtags": ["#hashtag1", "#hashtag2", "#hashtag3"]
-  }}
-}}
+Synthesis must reflect cross-source patterns, not a simple concatenation.
+If you lack information for a field, return "" or [] for that field.

--- a/backend/models/schemas.py
+++ b/backend/models/schemas.py
@@ -1,7 +1,30 @@
 """Data models and schemas"""
 from dataclasses import dataclass
-from typing import List, Dict, Any, Optional
 from datetime import datetime
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ArticleAnalysis(BaseModel):
+    """Structured summary for a single article."""
+
+    overview: str
+    key_insights: List[str]
+    outstaffer_opportunity: str
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class MultiArticleAnalysis(BaseModel):
+    """Structured synthesis across multiple articles."""
+
+    overview: str
+    key_insights: List[str]
+    outstaffer_opportunity: str
+    cross_article_themes: List[str] = Field(default_factory=list)
+
+    model_config = ConfigDict(extra="forbid")
 
 
 @dataclass

--- a/backend/tests/test_quick_research_models.py
+++ b/backend/tests/test_quick_research_models.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import json
+import pathlib
+import sys
+
+import pytest
+from pydantic import ValidationError
+
+PROJECT_ROOT = pathlib.Path(__file__).resolve().parents[2]
+sys.path[:0] = [str(PROJECT_ROOT), str(PROJECT_ROOT / "backend")]
+
+from core.pipeline import ContentPipeline
+from models.schemas import ArticleAnalysis, MultiArticleAnalysis
+
+
+def _validate_schema(model, payload, extra_key) -> None:
+    model.model_validate_json(json.dumps(payload))
+    with pytest.raises(ValidationError):
+        model.model_validate_json(json.dumps({**payload, extra_key: True}))
+
+
+def test_article_analysis_schema_contract() -> None:
+    _validate_schema(
+        ArticleAnalysis,
+        {"overview": "Article overview.", "key_insights": ["Insight A", "Insight B", "Insight C"], "outstaffer_opportunity": "Opportunity note."},
+        "unexpected",
+    )
+
+
+def test_multi_article_analysis_schema_contract() -> None:
+    _validate_schema(
+        MultiArticleAnalysis,
+        {"overview": "Multi-source overview.", "key_insights": ["Theme A", "Theme B", "Theme C", "Theme D", "Theme E"], "outstaffer_opportunity": "Multi opportunity.", "cross_article_themes": ["Pattern 1", "Pattern 2", "Pattern 3"]},
+        "extra_field",
+    )
+
+
+class DummyGemini:
+    def __init__(self, article_payload: dict, multi_payload: dict) -> None:
+        self.article = ArticleAnalysis.model_validate(article_payload)
+        self.multi = MultiArticleAnalysis.model_validate(multi_payload)
+
+    def analyze_article_structured(self, *_args, **_kwargs) -> ArticleAnalysis: return self.article  # noqa: D401
+
+    def synthesize_multi_article_analysis(self, *_args, **_kwargs) -> MultiArticleAnalysis: return self.multi
+
+
+def _pipeline_with(dummy: DummyGemini) -> ContentPipeline:
+    pipeline = ContentPipeline.__new__(ContentPipeline)  # type: ignore[call-arg]
+    pipeline.gemini = dummy  # type: ignore[attr-defined]
+    return pipeline
+
+
+def test_pipeline_returns_structured_dicts() -> None:
+    article_payload = {"overview": "", "key_insights": [], "outstaffer_opportunity": ""}
+    multi_payload = {"overview": "Cross-source perspective.", "key_insights": ["Insight one", "Insight two"], "outstaffer_opportunity": "Clear opportunity.", "cross_article_themes": ["Theme"]}
+    dummy = DummyGemini(article_payload, multi_payload)
+    pipeline = _pipeline_with(dummy)
+    assert pipeline.analyze_content("partial content") == article_payload
+    result = pipeline.synthesize_article("remote hiring", [{"url": "https://example.com", "title": "", "markdown": ""}])
+    assert result == multi_payload


### PR DESCRIPTION
## Summary
- add structured ArticleAnalysis and MultiArticleAnalysis models and wire Gemini client to request schema-constrained JSON
- update prompts, pipeline, and API endpoints so quick research analysis and synthesis return strict JSON objects
- simplify Content Finder rendering to plain text with JSON copy/download helpers and add tests for schema validation

## Testing
- pytest backend/tests/test_quick_research_models.py

------
https://chatgpt.com/codex/tasks/task_b_68e44d779d6083278605af571271362e